### PR TITLE
Update elkserver_cron_redelk.j2

### DIFF
--- a/templates/elkserver_cron_redelk.j2
+++ b/templates/elkserver_cron_redelk.j2
@@ -12,7 +12,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # m h dom mon dow user  command
 #*/2 * * * * redelk /usr/share/redelk/bin/getremotelogs.sh $IP $HOSTNAME scponly
 {% for host in groups['c2servers'] -%}
-*/2 * * * * redelk /usr/share/redelk/bin/getremotelogs.sh {{ inventory_hostname }} scponly
+*/2 * * * * redelk /usr/share/redelk/bin/getremotelogs.sh {{ host }} {{ hostvars[host]['filebeat_id'] }} scponly
 {% endfor %}
 
 # Run update script for TOR exit nodes twice a day


### PR DESCRIPTION
There was an issue where downloads and log directories on teamservers were not being rsync'd from teamserver to redelk in the redelk cron job.  This was preventing downloads, screenshots, etc.. from being available to redelk reports/queries.  

getremotelogs.sh expects 3 variables, first is the remote teamserver ip/dns, then hostname based on filebeat id, then ssh user.  Currently it only provides the inventory_hostname, which at run time is the redelk server, not the teamserver(s), and the ssh user of scponly.